### PR TITLE
Optionally set/change the DNS Server where the script resolves the current IP

### DIFF
--- a/dynhost.sh
+++ b/dynhost.sh
@@ -4,11 +4,12 @@
 HOST=DOMAINE_NAME
 LOGIN=LOGIN
 PASSWORD=PASSWORD
+DNSSERVER=@dns102.ovh.net
 
 PATH_LOG=/var/log/dynhostovh.log
 
 # Get current IPv4 and corresponding configured
-HOST_IP=$(dig +short $HOST A)
+HOST_IP=$(dig $DNSSERVER +short $HOST A)
 CURRENT_IP=$(curl -m 5 -4 ifconfig.co 2>/dev/null)
 if [ -z $CURRENT_IP ]
 then


### PR DESCRIPTION
Sometimes the local resolve of the host can be a different IP then publicly provided by the DNS server. E.g. in a local network or for compatibility the host can be specified in /etc/hosts if resolved on the local machine, or that the local router resolves it to a local IP.

By explicitly specifying to resolve the IP from OVH's DNS server you get the public IP.